### PR TITLE
Supply a default region for AWS CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ push:
 shell:
 	docker run --rm -it \
 		-e AWS_REGION \
+		-e AWS_DEFAULT_REGION=${AWS_REGION} \
 		-e AWS_ACCESS_KEY_ID \
 		-e AWS_SECRET_ACCESS_KEY \
 		$(IMAGE) bash


### PR DESCRIPTION
Provide `AWS_DEFAULT_REGION`, which the `aws` tool uses in preference to `AWS_REGION`

/cc @ags