### PR TITLE
Default registry to public DockerHub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 PROJECT       ?= docker-awscli
-REGISTRY      ?= quay.io/flippa
+REGISTRY      ?= flippa
 TAG           ?= v4
 IMAGE          = $(REGISTRY)/$(PROJECT):$(TAG)
 LATEST         = $(REGISTRY)/$(PROJECT):latest
 
-.PHONY: image push shell
+.PHONY: build push shell
 
-image:
+build:
 	docker build --rm -t $(IMAGE) .
 	docker tag -f $(IMAGE) $(LATEST)
 


### PR DESCRIPTION
## Background

We host this image publically because there is nothing senstive involved.

## What's this PR do?

Change the default registry to just `flippa`, causing it to go via Docker Hub.